### PR TITLE
Adding pip and trame to meta.yml. Import when installing via conda.

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -21,12 +21,14 @@ requirements:
     - numpy >=1.18
     - pyvista >=0.42
     - LoopStructural >=v1.6.4
+    - pip
 
 test:
   import:
     - numpy
     - pandas
     - loopstructural
+    - trame
 
 
 about:


### PR DESCRIPTION
I had to install trame manually to have the visualiser working in non-static in my environment, so I decided to add it to the requirements.